### PR TITLE
Correctly match all domains and wildcard domains

### DIFF
--- a/pycookiecheat/pycookiecheat.py
+++ b/pycookiecheat/pycookiecheat.py
@@ -116,9 +116,7 @@ def generate_host_keys(hostname):
 
     """
     labels = hostname.split('.')
-    is_country_tld = (len(labels[-1]) == 2)
-    start = 3 if is_country_tld else 2
-    for i in range(start, len(labels) + 1):
+    for i in range(2, len(labels) + 1):
         domain = '.'.join(labels[-i:])
         yield domain
         yield '.' + domain

--- a/pycookiecheat/pycookiecheat.py
+++ b/pycookiecheat/pycookiecheat.py
@@ -80,19 +80,17 @@ def chrome_cookies(url, cookie_file=None):
     # Part of the domain name that will help the sqlite3 query pick it from the
     # Chrome cookies
     domain = urlparse(url).netloc
-    domain_no_sub = '.'.join(domain.split('.')[-2:])
 
     conn = sqlite3.connect(cookie_file)
 
     sql = 'select name, value, encrypted_value from cookies where host_key '\
-          'like "%{0}%"'.format(domain_no_sub)
+          'like ?'
 
     cookies = {}
-    cookies_list = []
 
-    with conn:
-        for k, v, ev in conn.execute(sql):
-
+    for host_key in generate_host_keys(domain):
+        cookies_list = []
+        for k, v, ev in conn.execute(sql, (host_key,)):
             # if there is a not encrypted value or if the encrypted value
             # doesn't start with the 'v10' prefix, return v
             if v or (ev[:3] != b'v10'):
@@ -102,4 +100,25 @@ def chrome_cookies(url, cookie_file=None):
                 cookies_list.append(decrypted_tuple)
         cookies.update(cookies_list)
 
+    conn.rollback()
     return cookies
+
+
+def generate_host_keys(hostname):
+    """Yield Chrome keys for `hostname`, from least to most specific.
+
+    Given a hostname like foo.example.com, this yields the key sequence:
+
+    example.com
+    .example.com
+    foo.example.com
+    .foo.example.com
+
+    """
+    labels = hostname.split('.')
+    is_country_tld = (len(labels[-1]) == 2)
+    start = 3 if is_country_tld else 2
+    for i in range(start, len(labels) + 1):
+        domain = '.'.join(labels[-i:])
+        yield domain
+        yield '.' + domain


### PR DESCRIPTION
I was not able to log into a web site because it created cookies beneath the `example.com` level, putting several of them instead down at the `foo.example.com` level for the particular service it was trying to access. Furthermore, some of them were specified using the wildcard `.foo.example.com` so that they would be delivered to subdomains of `foo` as well — but a leading `.` was not previously allowed by this library, meaning that these cookies were left out of my requests.

This patch descends through the possible domain name matches in the same order that a browser should, and allows my Python script to successfully authenticate to the service that I was previously locked out of!

Also, this tweaks the code to avoid a possible encoding problem with hand-quoted domain names that include special characters — by relying on the sqlite3 "?" quoting character to get the quoting correct.