### PR TITLE
Chromium stores keys in different places than Chrome

### DIFF
--- a/pycookiecheat/pycookiecheat.py
+++ b/pycookiecheat/pycookiecheat.py
@@ -64,41 +64,37 @@ def chrome_decrypt(encrypted_value: bytes, key: bytes, init_vector: bytes) \
     return clean(decrypted)
 
 
-def get_osx_config(browser_name: str = None) -> dict:
+def get_osx_config(browser: str) -> dict:
     """Get settings for getting Chrome/Chromium cookies on OSX.
 
     Returns:
         Config dictionary for Chrome/Chromium cookie decryption
 
     """
-    if browser_name is None:
-        browser_name = 'Chrome'
-    if browser_name == 'Chrome':
-        cookie_dir = 'Google/' + browser_name
+    if browser == 'Chrome':
+        cookie_dir = 'Google/' + browser
     else:
-        cookie_dir = browser_name
+        cookie_dir = browser
+
     config = {
         'my_pass': keyring.get_password(
-            browser_name + ' Safe Storage', browser_name),
+            '{} Safe Storage'.format(browser), browser),
         'iterations': 1003,
-        'cookie_file': ('~/Library/Application Support/%s/Default/'
-                        'Cookies') % (cookie_dir,),
+        'cookie_file': ('~/Library/Application Support'
+                        '/{}/Default/Cookies'.format(cookie_dir)),
         }
     return config
 
 
-def get_linux_config(browser_name: str = None) -> dict:
-    """Get the settings for Chrome cookies on Linux.
+def get_linux_config(browser: str) -> dict:
+    """Get the settings for Chrome/Chromium cookies on Linux.
 
     Returns:
-        Config dictionary for Chrome cookie decryption
+        Config dictionary for Chrome/Chromium cookie decryption
 
     """
     # Set the default linux password
     config = {'my_pass': 'peanuts'}  # type: Dict[str, Union[int, str]]
-
-    if browser_name is None:
-        browser_name = 'Chrome'
 
     # Try to get from Gnome / libsecret if it seems available
     # https://github.com/n8henrie/pycookiecheat/issues/12
@@ -115,13 +111,11 @@ def get_linux_config(browser_name: str = None) -> dict:
         gnome_keyring = service.get_collections()
         unlocked_keyrings = service.unlock_sync(gnome_keyring).unlocked
 
+        keyring_name = "{} Safe Storage".format(browser)
+
         for unlocked_keyring in unlocked_keyrings:
             for item in unlocked_keyring.get_items():
-                if item.get_label() == browser_name + " Safe Storage":
-                    item.load_secret_sync()
-                    config['my_pass'] = item.get_secret().get_text()
-                    break
-                elif item.get_label() == "Chrome Safe Storage":
+                if item.get_label() == keyring_name:
                     item.load_secret_sync()
                     config['my_pass'] = item.get_secret().get_text()
                     break
@@ -132,9 +126,14 @@ def get_linux_config(browser_name: str = None) -> dict:
             # Inner loop did `break`, so `break` outer loop
             break
 
+    if browser == 'Chrome':
+        cookie_dir = 'google-chrome'
+    else:
+        cookie_dir = browser.lower()
+
     config.update({
         'iterations': 1,
-        'cookie_file': '~/.config/chromium/Default/Cookies',
+        'cookie_file': '~/.config/{}/Default/Cookies'.format(cookie_dir),
         })
     return config
 
@@ -142,22 +141,26 @@ def get_linux_config(browser_name: str = None) -> dict:
 def chrome_cookies(
         url: str,
         cookie_file: str = None,
-        browser_name: str = None) -> dict:
-    """Retrieve cookies from Chrome or Chromium on OSX or Linux.
+        browser: str = "Chrome") -> dict:
+    """Retrieve cookies from Chrome/Chromium on OSX or Linux.
 
     Args:
         url: Domain from which to retrieve cookies, starting with http(s)
         cookie_file: Path to alternate file to search for cookies
+        browser: Name of the browser's cookies to read ('Chrome' or 'Chromium')
     Returns:
         Dictionary of cookie values for URL
 
     """
+    # Check that the requested browser is supported
+    if browser not in ("Chrome", "Chromium"):
+        raise ValueError("Please use either Chrome or Chromium as browser.")
+
     # If running Chrome on OSX
     if sys.platform == 'darwin':
-        config = get_osx_config(browser_name)
-
+        config = get_osx_config(browser)
     elif sys.platform.startswith('linux'):
-        config = get_linux_config(browser_name)
+        config = get_linux_config(browser)
     else:
         raise OSError("This script only works on OSX or Linux.")
 

--- a/pycookiecheat/pycookiecheat.py
+++ b/pycookiecheat/pycookiecheat.py
@@ -44,7 +44,7 @@ def clean(decrypted: bytes) -> str:
 
 def chrome_decrypt(encrypted_value: bytes, key: bytes, init_vector: bytes) \
         -> str:
-    """Decrypt Chrome/Chromiums's encrypted cookies.
+    """Decrypt Chrome/Chromium's encrypted cookies.
 
     Args:
         encrypted_value: Encrypted cookie value from Chrome/Chromium's cookie file

--- a/pycookiecheat/pycookiecheat.py
+++ b/pycookiecheat/pycookiecheat.py
@@ -137,7 +137,7 @@ def get_linux_config(browser_name: str = None) -> dict:
     return config
 
 
-def chrome_cookies(url: str, cookie_file: str = None, , browser_name: str = None) -> dict:
+def chrome_cookies(url: str, cookie_file: str = None, browser_name: str = None) -> dict:
     """Retrieve cookies from Chrome or Chromium on OSX or Linux.
 
     Args:

--- a/pycookiecheat/pycookiecheat.py
+++ b/pycookiecheat/pycookiecheat.py
@@ -98,7 +98,7 @@ def get_linux_config(browser_name: str = None) -> dict:
     config = {'my_pass': 'peanuts'}  # type: Dict[str, Union[int, str]]
 
     if browser_name is None:
-        browser_name = 'Chromium'
+        browser_name = 'Chrome'
 
     # Try to get from Gnome / libsecret if it seems available
     # https://github.com/n8henrie/pycookiecheat/issues/12
@@ -131,6 +131,7 @@ def get_linux_config(browser_name: str = None) -> dict:
 
             # Inner loop did `break`, so `break` outer loop
             break
+
     config.update({
         'iterations': 1,
         'cookie_file': '~/.config/chromium/Default/Cookies',

--- a/pycookiecheat/pycookiecheat.py
+++ b/pycookiecheat/pycookiecheat.py
@@ -47,7 +47,7 @@ def chrome_decrypt(encrypted_value: bytes, key: bytes, init_vector: bytes) \
     """Decrypt Chrome/Chromium's encrypted cookies.
 
     Args:
-        encrypted_value: Encrypted cookie value from Chrome/Chromium's cookie file
+        encrypted_value: Encrypted cookie from Chrome/Chromium's cookie file
         key: Key to decrypt encrypted_value
         init_vector: Initialization vector for decrypting encrypted_value
     Returns:
@@ -78,7 +78,8 @@ def get_osx_config(browser_name: str = None) -> dict:
     else:
         cookie_dir = browser_name
     config = {
-        'my_pass': keyring.get_password(browser_name + ' Safe Storage', browser_name),
+        'my_pass': keyring.get_password(
+            browser_name + ' Safe Storage', browser_name),
         'iterations': 1003,
         'cookie_file': ('~/Library/Application Support/%s/Default/'
                         'Cookies') % (cookie_dir,),
@@ -137,7 +138,10 @@ def get_linux_config(browser_name: str = None) -> dict:
     return config
 
 
-def chrome_cookies(url: str, cookie_file: str = None, browser_name: str = None) -> dict:
+def chrome_cookies(
+        url: str,
+        cookie_file: str = None,
+        browser_name: str = None) -> dict:
     """Retrieve cookies from Chrome or Chromium on OSX or Linux.
 
     Args:


### PR DESCRIPTION
I found the Chromium on Ubuntu 16.04 stores keys in the keyring "Chromium Safe Storage", not "Chrome Safe Storage".  The profile directory is different for Chromium on OSX as well.