### PR TITLE
Added an option to save cookies to file to be used with cURL

### DIFF
--- a/src/pycookiecheat/pycookiecheat.py
+++ b/src/pycookiecheat/pycookiecheat.py
@@ -202,7 +202,14 @@ def chrome_cookies(
         print("Unable to connect to cookie_file at: {}\n".format(cookie_file))
         raise
 
-    sql = ('select host_key, path, is_secure, expires_utc, name, value, encrypted_value '
+    # Check whether the column name is `secure` or `is_secure`
+    secure_column_name = 'is_secure'
+    for sl_no, column_name, data_type, is_null, default_val, pk in conn.execute('PRAGMA table_info(cookies)'):
+        if column_name == 'secure':
+            secure_column_name = 'secure'
+            break
+
+    sql = ('select host_key, path, ' + secure_column_name + ', expires_utc, name, value, encrypted_value '
            'from cookies where host_key like ?')
 
     cookies = dict()


### PR DESCRIPTION
Hi, I've added another optional argument (`curl_cookie_file`) to the `chrome_cookies` function which takes the path to file where the cookies are to be saved. 

Here's a quick example for convenience:
```python
from pycookiecheat import chrome_cookies

dir_path = "/tmp/google.com"
url = 'https://google.com'
chrome_cookies(url, curl_cookie_file=dir_path)
```

The generated file can be used with cURL directly.
```bash
curl -c /tmp/google.com https://google.com
```