### PR TITLE
Add support for Brave cookies.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
           - "3.9"
 
     env:
-      TOX_TESTENV_PASSENV: "XAUTHORITY DISPLAY"
+      TOX_TESTENV_PASSENV: "XAUTHORITY DISPLAY TEST_BROWSER_NAME TEST_BROWSER_PATH"
 
     steps:
     - uses: actions/checkout@v2
@@ -34,7 +34,20 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install tox
       run: python -m pip install "tox>=3,<4"
-    - name: Run tests via tox
+    - name: Install Brave
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y apt-transport-https curl
+        curl -s https://brave-browser-apt-release.s3.brave.com/brave-core.asc | sudo apt-key add -
+        echo "deb [arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main" | sudo tee /etc/apt/sources.list.d/brave-browser-release.list
+        sudo apt-get update
+        sudo apt-get install --yes brave-browser
+    - name: Run tests via tox (Chromium)
+      run: xvfb-run -- python -m tox -e py
+    - name: Run tests via tox (Brave)
+      env:
+        TEST_BROWSER_NAME: Brave
+        TEST_BROWSER_PATH: /usr/bin/brave-browser
       run: xvfb-run -- python -m tox -e py
     - if: "matrix.python-version == '3.9'"
       name: Lint

--- a/src/pycookiecheat/pycookiecheat.py
+++ b/src/pycookiecheat/pycookiecheat.py
@@ -88,7 +88,10 @@ def get_osx_config(browser: str) -> dict:
     elif browser.lower() == "chromium":
         cookie_file = "~/Library/Application Support/Chromium/Default/Cookies"
     elif browser.lower() == "brave":
-        cookie_file = "~/Library/Application Support/BraveSoftware/Brave-Browser/Default/Cookies"
+        cookie_file = (
+            "~/Library/Application Support/"
+            "BraveSoftware/Brave-Browser/Default/Cookies"
+        )
     else:
         raise ValueError("Browser must be either Chrome, Chromium, or Brave.")
 

--- a/src/pycookiecheat/pycookiecheat.py
+++ b/src/pycookiecheat/pycookiecheat.py
@@ -75,7 +75,7 @@ def get_osx_config(browser: str) -> dict:
     """Get settings for getting Chrome/Chromium cookies on OSX.
 
     Args:
-        browser: Either "Chrome" or "Chromium"
+        browser: Either "Chrome", "Chromium", or "Brave"
     Returns:
         Config dictionary for Chrome/Chromium cookie decryption
 
@@ -87,8 +87,10 @@ def get_osx_config(browser: str) -> dict:
         )
     elif browser.lower() == "chromium":
         cookie_file = "~/Library/Application Support/Chromium/Default/Cookies"
+    elif browser.lower() == "brave":
+        cookie_file = "~/Library/Application Support/BraveSoftware/Brave-Browser/Default/Cookies"
     else:
-        raise ValueError("Browser must be either Chrome or Chromium.")
+        raise ValueError("Browser must be either Chrome, Chromium, or Brave.")
 
     config = {
         "my_pass": keyring.get_password(
@@ -104,7 +106,7 @@ def get_linux_config(browser: str) -> dict:
     """Get the settings for Chrome/Chromium cookies on Linux.
 
     Args:
-        browser: Either "Chrome" or "Chromium"
+        browser: Either "Chrome", "Chromium", or "Brave"
     Returns:
         Config dictionary for Chrome/Chromium cookie decryption
 
@@ -114,8 +116,10 @@ def get_linux_config(browser: str) -> dict:
         cookie_file = "~/.config/google-chrome/Default/Cookies"
     elif browser.lower() == "chromium":
         cookie_file = "~/.config/chromium/Default/Cookies"
+    elif browser.lower() == "brave":
+        cookie_file = "~/.config/BraveSoftware/Brave-Browser/Default/Cookies"
     else:
-        raise ValueError("Browser must be either Chrome or Chromium.")
+        raise ValueError("Browser must be either Chrome, Chromium, or Brave.")
 
     # Set the default linux password
     config = {

--- a/tests/test_pycookiecheat.py
+++ b/tests/test_pycookiecheat.py
@@ -1,5 +1,6 @@
 """test_pycookiecheat.py :: Tests for pycookiecheat module."""
 
+import os
 import time
 import typing as t
 from pathlib import Path
@@ -46,6 +47,7 @@ def ci_setup() -> t.Generator:
             ignore_default_args=[
                 "--use-mock-keychain",
             ],
+            executable_path=os.environ.get("TEST_BROWSER_PATH"),
         )
         page = browser.new_page()
         page.goto("https://n8henrie.com")
@@ -87,7 +89,7 @@ def test_no_cookies(ci_setup: str) -> None:
     empty_dict = chrome_cookies(
         never_been_here,
         cookie_file=ci_setup,
-        browser="Chromium",
+        browser=os.environ.get("TEST_BROWSER_NAME", "Chromium"),
     )
     assert empty_dict == dict()
 
@@ -101,7 +103,7 @@ def test_fake_cookie(ci_setup: str) -> None:
     cookies = chrome_cookies(
         "https://n8henrie.com",
         cookie_file=ci_setup,
-        browser="Chromium",
+        browser=os.environ.get("TEST_BROWSER_NAME", "Chromium"),
     )
     assert cookies.get("test_pycookiecheat") == "It worked!"
 


### PR DESCRIPTION
## Description
This adds support for fetching cookies from Brave, a relatively popular Chromium-based browser. It works essentially the same as any other Chromium derivative where it uses a different keyring entry and cookie file path, but otherwise uses exactly the same encryption mechanism as Chromium.

## Status

**READY**

## Todos

- [ ] Tests
  - I've not added any tests for this, since there weren't any existing ones for this method parameter. It's quite difficult to unit-test unfortunately. I'm happy to implement any suggestions on this front though.
- [x] Documentation
  - Updated method documentation to indicate that `browser="Brave"` is a supported option.

## Steps to Test or Reproduce
Install Brave. Generate some cookies. Fetch those cookies.
```
Python 3.8.10 (default, Nov 14 2022, 12:59:47) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pycookiecheat
>>> pycookiecheat.chrome_cookies(url="https://httpbin.org/", browser="Brave")
{'test': 'value'}
```