### PR TITLE
Support Slack app cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ manually specify something like
 
 ## Features
 
-- Returns decrypted cookies from Google Chrome on OSX or Linux.
+- Returns decrypted cookies from Google Chrome or Slack, on OSX or Linux.
 - Optionally outputs cookies to file (thanks to Muntashir Al-Islam!)
 
 ## FAQ / Troubleshooting

--- a/src/pycookiecheat/pycookiecheat.py
+++ b/src/pycookiecheat/pycookiecheat.py
@@ -88,7 +88,11 @@ def get_osx_config(browser: str) -> dict:
     elif browser.lower() == "chromium":
         cookie_file = "~/Library/Application Support/Chromium/Default/Cookies"
     elif browser.lower() == "slack":
-        cookie_file = "~/Library/Application Support/Slack/Cookies"
+        cookie_file = "~/Library/Application Support/Slack/Cookies" # installed via direct download
+        # Alas, the cookies can be in two places on macos (well, one place, but possibly via that insane
+        # sandboxing of the filesystem that goes on now) so we have to hit the filesystem to check.
+        if not pathlib.Path(cookie_file).expanduser().exists():
+            cookie_file = "~/Library/Containers/com.tinyspeck.slackmacgap/Data" + cookie_file[1:] # installed from App Store
     else:
         raise ValueError("Browser must be either Chrome, Chromium or Slack.")
 

--- a/src/pycookiecheat/pycookiecheat.py
+++ b/src/pycookiecheat/pycookiecheat.py
@@ -88,11 +88,17 @@ def get_osx_config(browser: str) -> dict:
     elif browser.lower() == "chromium":
         cookie_file = "~/Library/Application Support/Chromium/Default/Cookies"
     elif browser.lower() == "slack":
-        cookie_file = "~/Library/Application Support/Slack/Cookies" # installed via direct download
-        # Alas, the cookies can be in two places on macos (well, one place, but possibly via that insane
-        # sandboxing of the filesystem that goes on now) so we have to hit the filesystem to check.
+        # Alas, the cookies can be in two places on macos (well, one place,
+        # but possibly via that insane sandboxing of the filesystem that
+        # goes on now) so we have to hit the filesystem to check.
+        # This is the location is Slack is installed via direct download.
+        cookie_file = "~/Library/Application Support/Slack/Cookies"
         if not pathlib.Path(cookie_file).expanduser().exists():
-            cookie_file = "~/Library/Containers/com.tinyspeck.slackmacgap/Data" + cookie_file[1:] # installed from App Store
+            # And this location if Slack is installed from App Store
+            cookie_file = (
+              "~/Library/Containers/com.tinyspeck.slackmacgap/Data"
+              + cookie_file[1:]
+            )
     else:
         raise ValueError("Browser must be either Chrome, Chromium or Slack.")
 
@@ -152,14 +158,16 @@ def get_linux_config(browser: str) -> dict:
         if browser.lower() == "chrome":
             keyring_name = "Chrome Safe Storage"
         else:
-            # While Slack on Linux has its own Cookies file, the password is stored in a keyring
-            # named the same as Chromium's, but with an "application" attribute of "Slack".
+            # While Slack on Linux has its own Cookies file, the password
+            # is stored in a keyring named the same as Chromium's, but with
+            # an "application" attribute of "Slack".
             keyring_name = "Chromium Safe Storage"
 
         for unlocked_keyring in unlocked_keyrings:
             for item in unlocked_keyring.get_items():
                 if item.get_label() == keyring_name:
-                    item_app = item.get_attributes().get('application', browser)
+                    item_app = item.get_attributes() \
+                                   .get('application', browser)
                     if item_app.lower() != browser.lower():
                         continue
                     item.load_secret_sync()

--- a/tests/test_pycookiecheat.py
+++ b/tests/test_pycookiecheat.py
@@ -11,6 +11,7 @@ import pytest
 from playwright.sync_api import sync_playwright
 
 from pycookiecheat import chrome_cookies
+from pycookiecheat.pycookiecheat import get_linux_config, get_osx_config
 
 
 @pytest.fixture(scope="module")
@@ -110,3 +111,31 @@ def test_raises_on_wrong_browser() -> None:
     """Passing a browser other than Chrome or Chromium raises ValueError."""
     with pytest.raises(ValueError):
         chrome_cookies("https://n8henrie.com", browser="Safari")
+
+
+def test_slack_app_macos_config() -> None:
+    """Tests configuring for cookies from the macos Slack app.
+
+    Hard to come up with a mock test, since the only functionality provided by
+    the Slack app feature is to read cookies from a different file. So opt to
+    just test that new functionality with something simple and fairly robust.
+    """
+    cfg1 = get_osx_config("slack")
+    cfg2 = get_osx_config("SLACK")
+
+    assert cfg1 == cfg2
+    assert "Slack" in cfg1['cookie_file']
+
+
+def test_slack_app_linux_config() -> None:
+    """Tests a cookie can be retrieved from the Linux Slack app.
+
+    Hard to come up with a mock test, since the only functionality provided by
+    the Slack app feature is to read cookies from a different file. So opt to
+    just test that new functionality with something simple and fairly robust.
+    """
+    cfg1 = get_linux_config("slack")
+    cfg2 = get_linux_config("SLACK")
+
+    assert cfg1 == cfg2
+    assert "Slack" in cfg1['cookie_file']


### PR DESCRIPTION
## Description

Add the **Slack desktop app** alongside Chrome and Chromium as "browsers" from which cookies can be pulled. The use cases for extracting cookies from a browser (eg. to browse web pages) might be slightly different to the use cases for extracting cookies from Slack (eg. to access the Slack API manually). Nonetheless, the way the cookies are stored is practically identical and `pycookiecheat` provides a very suitable basis for extracting them in either case.

## Status

**READY**

Specifically: used by the author for several months; support for both standalone app and App Store app recently added; basic tests added recently and verified; code linted.

## Related Issues

- [Enhancement request](https://github.com/n8henrie/pycookiecheat/issues/39)

## Todos

- [X] Tests
- [X] Documentation
  - "Slack" mentioned alongside "Chrome" and "Chromium" in README.
  - Additionally, possibilities for package metadata updates are [this commit](https://github.com/hraftery/pycookiecheat/commit/a2ef34986147e601f65b0456b8657bc9aa89fae6), which was written for the fork.

## Steps to Test or Reproduce

```bash
pip install pycookiecheat-slack
python -c '
from pycookiecheat import chrome_cookies
cookies = chrome_cookies("http://slack.com", browser="Slack")
print("Token: " + cookies["d"])'
```

## Other notes

The motivating use-case is [here](https://github.com/hraftery/slacktokens/blob/73a7085dc73627d84d0c49fe5a3423ff144e66f1/slacktokens.py#L91).
