### PR TITLE
Add Arc browser support for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Linux) as your `cookie_file`.
 
 ## Features
 
-- Returns decrypted cookies from Google Chrome, Brave, or Slack, on OSX or
-  Linux.
+- Returns decrypted cookies from Google Chrome, Brave, Slack, on macOS or
+  Linux, and Arc on macOS
 - Optionally outputs cookies to file (thanks to Muntashir Al-Islam!)
 
 ## FAQ / Troubleshooting

--- a/src/pycookiecheat/chrome.py
+++ b/src/pycookiecheat/chrome.py
@@ -85,20 +85,24 @@ def get_osx_config(browser: str) -> dict:
     # Verify supported browser, fail early otherwise. Mind the capitalization,
     # which is necessary for the password retrieval.
     browser = browser.title()
+    app_support = "~/Library/Application Support"
+    browsers = {
+        "Chrome": f"{app_support}/Google/Chrome/Default/Cookies",
+        "Chromium": f"{app_support}/Chromium/Default/Cookies",
+        "Brave": (
+            f"{app_support}/BraveSoftware/Brave-Browser/Default/Cookies"
+        ),
+        "Slack": f"{app_support}/Slack/Cookies",
+        "Arc": f'{app_support}/Arc/User Data/Default/Cookies',
+    }
     try:
-        app_support = "~/Library/Application Support"
-        cookie_file = {
-            "Chrome": f"{app_support}/Google/Chrome/Default/Cookies",
-            "Chromium": f"{app_support}/Chromium/Default/Cookies",
-            "Brave": (
-                f"{app_support}/BraveSoftware/Brave-Browser/Default/Cookies"
-            ),
-            "Slack": f"{app_support}/Slack/Cookies",
-        }[browser]
+        cookie_file = browsers[browser]
     except KeyError:
+        supported_browsers = list(browsers)
         raise ValueError(
-            "Browser must be either Chrome, Chromium, Slack, or Brave, "
-            "but found {browser}"
+            f"Browser must be either {', '.join(supported_browsers[:-1])} "
+            f"or {supported_browsers[-1]}, "
+            f"but found {browser}"
         )
 
     # Alas, the cookies can be in two places on MacOS (well, one place, but


### PR DESCRIPTION
## Description

Added Arc browser support — just a new configuration file in existing dictionary + some minor change in error repr
 
## Status

**READY**

## Steps to Test or Reproduce


```bash
git checkout -b patch-1 master
git pull https://github.com/Bobronium/pycookiecheat.git patch-1
python -c 'from pycookiecheat import chrome_cookies; print(chrome_cookies("https://example.com", browser="Arc"))'
```

