### PR TITLE
Browser enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Linux) as your `cookie_file`.
 
 ## Features
 
-- Returns decrypted cookies from Google Chrome, Brave, or Slack, on OSX or
+- Returns decrypted cookies from Google Chrome, Brave, or Slack, on MacOS or
   Linux.
 - Optionally outputs cookies to file (thanks to Muntashir Al-Islam!)
 

--- a/README.md
+++ b/README.md
@@ -42,23 +42,25 @@ Alternatively, some users have suggested running Chrome with the
 ## Usage
 
 ```python
-from pycookiecheat import chrome_cookies
+from pycookiecheat import BrowserType, chrome_cookies
 import requests
 
-url = 'http://example.com/fake.html'
+url = 'https://n8henrie.com'
 
 # Uses Chrome's default cookies filepath by default
 cookies = chrome_cookies(url)
 r = requests.get(url, cookies=cookies)
+
+# Using an alternate browser
+cookies = chrome_cookies(url, browser=BrowserType.CHROMIUM)
 ```
 
 Use the `cookie_file` keyword-argument to specify a different filepath for the
 cookies-file: `chrome_cookies(url, cookie_file='/abspath/to/cookies')`
 
-Keep in mind that pycookiecheat defaults to looking for cookies for Google
-Chrome, not Chromium, so if you're using the latter, you'll need to manually
-specify something like `"/home/username/.config/chromium/Default/Cookies"` (for
-Linux) as your `cookie_file`.
+You may be able to retrieve cookies for alternative Chromium-based browsers by
+manually specifying something like
+`"/home/username/.config/BrowserName/Default/Cookies"` as your `cookie_file`.
 
 ## Features
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696009558,
-        "narHash": "sha256-/1nNL8lCF0gn38XaFyu2ufpWcBFwCDZyYUxdZkM6GxU=",
+        "lastModified": 1703499205,
+        "narHash": "sha256-lF9rK5mSUfIZJgZxC3ge40tp1gmyyOXZ+lRY3P8bfbg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c182df2e68bd97deb32c7e4765adfbbbcaf75b60",
+        "rev": "e1fa12d4f6c6fe19ccb59cac54b5b3f25e160870",
         "type": "github"
       },
       "original": {
@@ -16,9 +16,26 @@
         "type": "github"
       }
     },
+    "nixpkgs-old": {
+      "locked": {
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-old": "nixpkgs-old"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,21 @@
         };
 
         devShells.${system}.default = pkgs.mkShell {
-          buildInputs = [(pkgs.python311.withPackages (_: propagatedBuildInputs))];
+          buildInputs = with pkgs; [
+            python37
+            python38
+            python39
+            python310
+            (python311.withPackages (
+              ps:
+                propagatedBuildInputs
+                ++ (with ps; [
+                  mypy
+                  pytest
+                  tox
+                ])
+            ))
+          ];
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,16 @@
 {
   description = "Flake for https://github.com/n8henrie/pycookiecheat";
 
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  inputs = {
+    # For python3.7
+    nixpkgs-old.url = "github:nixos/nixpkgs/release-22.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  };
 
   outputs = {
     self,
     nixpkgs,
+    nixpkgs-old,
   }: let
     inherit (nixpkgs) lib;
     systems = ["aarch64-darwin" "x86_64-linux" "aarch64-linux"];
@@ -18,7 +23,14 @@
   in
     systemClosure (
       system: let
-        pkgs = import nixpkgs {inherit system;};
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (_: _: {
+              inherit (nixpkgs-old.legacyPackages.${system}) python37;
+            })
+          ];
+        };
         pname = "pycookiecheat";
         propagatedBuildInputs = with pkgs.python311Packages; [
           cryptography

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ test = [
     "flake8-docstrings==1.5.0",
     "flake8-import-order==0.18.1",
     "flake8==3.8.4",
-    "mypy==1.8.0",
+    "mypy==1",
     "pep8-naming==0.11.1",
     "playwright==1.14.1",
     "pycodestyle==2.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ test = [
     "flake8-docstrings==1.5.0",
     "flake8-import-order==0.18.1",
     "flake8==3.8.4",
-    "mypy==0.991",
+    "mypy==1.8.0",
     "pep8-naming==0.11.1",
     "playwright==1.14.1",
     "pycodestyle==2.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ test = [
     "flake8-docstrings==1.5.0",
     "flake8-import-order==0.18.1",
     "flake8==3.8.4",
-    "mypy==1",
+    "mypy==1.4.1",
     "pep8-naming==0.11.1",
     "playwright==1.14.1",
     "pycodestyle==2.6.0",

--- a/src/pycookiecheat/__init__.py
+++ b/src/pycookiecheat/__init__.py
@@ -1,6 +1,7 @@
 """__init__.py :: Exposes chrome_cookies function."""
 
 from pycookiecheat.chrome import chrome_cookies
+from pycookiecheat.common import BrowserType
 from pycookiecheat.firefox import firefox_cookies
 
 __author__ = "Nathan Henrie"
@@ -8,6 +9,7 @@ __email__ = "nate@n8henrie.com"
 __version__ = "v0.6.0"
 
 __all__ = [
+    "BrowserType",
     "chrome_cookies",
     "firefox_cookies",
 ]

--- a/src/pycookiecheat/chrome.py
+++ b/src/pycookiecheat/chrome.py
@@ -78,7 +78,7 @@ def chrome_decrypt(
     return clean(decrypted)
 
 
-def get_osx_config(browser: BrowserType) -> dict:
+def get_macos_config(browser: BrowserType) -> dict:
     """Get settings for getting Chrome/Chromium cookies on MacOS.
 
     Args:
@@ -257,7 +257,7 @@ def chrome_cookies(
 
     # If running Chrome on MacOS
     if sys.platform == "darwin":
-        config = get_osx_config(browser)
+        config = get_macos_config(browser)
     elif sys.platform.startswith("linux"):
         config = get_linux_config(browser)
     else:

--- a/src/pycookiecheat/chrome.py
+++ b/src/pycookiecheat/chrome.py
@@ -26,9 +26,9 @@ from cryptography.hazmat.primitives.hashes import SHA1
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 from pycookiecheat.common import (
-    _deprecation_warning,
     BrowserType,
     Cookie,
+    deprecation_warning,
     generate_host_keys,
 )
 
@@ -242,7 +242,7 @@ def chrome_cookies(
 
     # TODO: 20231229 remove str support after some deprecation period
     if not isinstance(browser, BrowserType):
-        _deprecation_warning(
+        deprecation_warning(
             "Please pass `browser` as a `BrowserType` instead of "
             f"`{browser.__class__.__qualname__}`."
         )

--- a/src/pycookiecheat/chrome.py
+++ b/src/pycookiecheat/chrome.py
@@ -79,7 +79,7 @@ def chrome_decrypt(
 
 
 def get_osx_config(browser: BrowserType) -> dict:
-    """Get settings for getting Chrome/Chromium cookies on OSX.
+    """Get settings for getting Chrome/Chromium cookies on MacOS.
 
     Args:
         browser: Enum variant representing browser of interest
@@ -248,13 +248,13 @@ def chrome_cookies(
         )
         browser = BrowserType(browser)
 
-    # If running Chrome on OSX
+    # If running Chrome on MacOS
     if sys.platform == "darwin":
         config = get_osx_config(browser)
     elif sys.platform.startswith("linux"):
         config = get_linux_config(browser)
     else:
-        raise OSError("This script only works on OSX or Linux.")
+        raise OSError("This script only works on MacOS or Linux.")
 
     config.update(
         {"init_vector": b" " * 16, "length": 16, "salt": b"saltysalt"}

--- a/src/pycookiecheat/chrome.py
+++ b/src/pycookiecheat/chrome.py
@@ -260,10 +260,9 @@ def chrome_cookies(
         {"init_vector": b" " * 16, "length": 16, "salt": b"saltysalt"}
     )
 
-    if cookie_file is not None:
-        cookie_file = Path(cookie_file)
-    else:
+    if cookie_file is None:
         cookie_file = config["cookie_file"]
+    cookie_file = Path(cookie_file)
 
     if isinstance(password, bytes):
         config["my_pass"] = password

--- a/src/pycookiecheat/chrome.py
+++ b/src/pycookiecheat/chrome.py
@@ -106,7 +106,7 @@ def get_macos_config(browser: BrowserType) -> dict:
 
     # Slack cookies can be in two places on MacOS depending on whether it was
     # installed from the App Store or direct download.
-    if browser == BrowserType.SLACK and not cookie_file.exists():
+    if browser is BrowserType.SLACK and not cookie_file.exists():
         # And this location if Slack is installed from App Store
         cookie_file = (
             "~/Library/Containers/com.tinyspeck.slackmacgap/Data"
@@ -118,7 +118,7 @@ def get_macos_config(browser: BrowserType) -> dict:
     keyring_service_name = f"{browser_name} Safe Storage"
 
     keyring_username = browser_name
-    if browser == BrowserType.SLACK:
+    if browser is BrowserType.SLACK:
         keyring_username = "Slack Key"
 
     my_pass = keyring.get_password(keyring_service_name, keyring_username)

--- a/src/pycookiecheat/chrome.py
+++ b/src/pycookiecheat/chrome.py
@@ -218,7 +218,7 @@ def get_linux_config(browser: BrowserType) -> dict:
 def chrome_cookies(
     url: str,
     cookie_file: t.Optional[t.Union[str, Path]] = None,
-    browser: t.Optional[BrowserType] = None,
+    browser: t.Optional[BrowserType] = BrowserType.CHROME,
     curl_cookie_file: t.Optional[str] = None,
     password: t.Optional[t.Union[bytes, str]] = None,
 ) -> dict:
@@ -240,13 +240,8 @@ def chrome_cookies(
     else:
         raise urllib.error.URLError("You must include a scheme with your URL.")
 
-    # TODO: Refactor to match statement once depending on >= 3.10
-    if browser is None:
-        browser = BrowserType.CHROME
-    elif isinstance(browser, BrowserType):
-        pass
     # TODO: 20231229 remove str support after some deprecation period
-    else:
+    if not isinstance(browser, BrowserType):
         _deprecation_warning(
             "Please pass `browser` as a `BrowserType` instead of "
             f"`{browser.__class__.__qualname__}`."

--- a/src/pycookiecheat/chrome.py
+++ b/src/pycookiecheat/chrome.py
@@ -88,13 +88,20 @@ def get_osx_config(browser: BrowserType) -> dict:
 
     """
     app_support = Path("/Library/Application Support")
-    # TODO: Refactor to match statement once depending on >= 3.10
-    cookies_suffix = {
-        BrowserType.CHROME: "Google/Chrome/Default/Cookies",
-        BrowserType.CHROMIUM: "Chromium/Default/Cookies",
-        BrowserType.BRAVE: "BraveSoftware/Brave-Browser/Default/Cookies",
-        BrowserType.SLACK: "Slack/Cookies",
-    }[browser]
+    # TODO: Refactor to exhaustive match statement once depending on >= 3.10
+    try:
+        cookies_suffix = {
+            BrowserType.CHROME: "Google/Chrome/Default/Cookies",
+            BrowserType.CHROMIUM: "Chromium/Default/Cookies",
+            BrowserType.BRAVE: "BraveSoftware/Brave-Browser/Default/Cookies",
+            BrowserType.SLACK: "Slack/Cookies",
+        }[browser]
+    except KeyError as e:
+        errmsg = (
+            f"{browser} is not a valid BrowserType for {__name__}"
+            ".get_macos_config"
+        )
+        raise ValueError(errmsg) from e
     cookie_file = "~" / app_support / cookies_suffix
 
     # Slack cookies can be in two places on MacOS depending on whether it was

--- a/src/pycookiecheat/common.py
+++ b/src/pycookiecheat/common.py
@@ -1,6 +1,8 @@
 """Common code for pycookiecheat."""
 from dataclasses import dataclass
+from enum import auto, Enum
 from typing import Iterator
+from warnings import warn
 
 
 @dataclass
@@ -57,3 +59,46 @@ def generate_host_keys(hostname: str) -> Iterator[str]:
         domain = ".".join(labels[-i:])
         yield domain
         yield "." + domain
+
+
+def _deprecation_warning(msg: str):
+    warn(msg, DeprecationWarning, stacklevel=3)
+
+
+class BrowserType(str, Enum):
+    """Provide discrete values for recognized browsers.
+
+    This utility class helps ensure that the requested browser is specified
+    precisely or fails early by matching against user input; internally this
+    enum should be preferred as compared to passing strings.
+
+    >>> "chrome" == BrowserType.CHROME
+    True
+
+    TODO: consider using `enum.StrEnum` once pycookiecheat depends on python >=
+    3.11
+    """
+
+    BRAVE = "brave"
+    CHROME = "chrome"
+    CHROMIUM = "chromium"
+    FIREFOX = "firefox"
+    SLACK = "slack"
+
+    @classmethod
+    def _missing_(cls, value: str):
+        """Provide case-insensitive matching for input values.
+
+        >>> BrowserType("chrome")
+        <BrowserType.CHROME: 'chrome'>
+        >>> BrowserType("FiReFoX")
+        <BrowserType.FIREFOX: 'firefox'>
+        >>> BrowserType("edge")
+        Traceback (most recent call last):
+        ValueError: 'edge' is not a valid BrowserType
+        """
+        folded = value.casefold()
+        for member in cls:
+            if member.value == folded:
+                return member
+        raise ValueError("%r is not a valid %s" % (value, cls.__qualname__))

--- a/src/pycookiecheat/common.py
+++ b/src/pycookiecheat/common.py
@@ -79,7 +79,7 @@ class BrowserType(str, Enum):
     precisely or fails early by matching against user input; internally this
     enum should be preferred as compared to passing strings.
 
-    >>> "chrome" == BrowserType.CHROME
+    >>> "chrome" is BrowserType.CHROME
     True
 
     TODO: consider using `enum.StrEnum` once pycookiecheat depends on python >=

--- a/src/pycookiecheat/common.py
+++ b/src/pycookiecheat/common.py
@@ -109,4 +109,4 @@ class BrowserType(str, Enum):
         for member in cls:
             if member.value == folded:
                 return member
-        raise ValueError("%r is not a valid %s" % (value, cls.__qualname__))
+        raise ValueError(f"{value!r} is not a valid {cls.__qualname__}")

--- a/src/pycookiecheat/common.py
+++ b/src/pycookiecheat/common.py
@@ -1,6 +1,8 @@
 """Common code for pycookiecheat."""
+from __future__ import annotations
+
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, unique
 from typing import Iterator
 from warnings import warn
 
@@ -61,7 +63,7 @@ def generate_host_keys(hostname: str) -> Iterator[str]:
         yield "." + domain
 
 
-def deprecation_warning(msg: str):
+def deprecation_warning(msg: str) -> None:
     """Raise a deprecation warning with the provided message.
 
     `stacklevel=3` tries to show the appropriate calling code to the user.
@@ -69,6 +71,7 @@ def deprecation_warning(msg: str):
     warn(msg, DeprecationWarning, stacklevel=3)
 
 
+@unique
 class BrowserType(str, Enum):
     """Provide discrete values for recognized browsers.
 
@@ -89,8 +92,9 @@ class BrowserType(str, Enum):
     FIREFOX = "firefox"
     SLACK = "slack"
 
+    # https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
     @classmethod
-    def _missing_(cls, value: str):
+    def _missing_(cls, value: str) -> BrowserType:  # type: ignore[override]
         """Provide case-insensitive matching for input values.
 
         >>> BrowserType("chrome")

--- a/src/pycookiecheat/common.py
+++ b/src/pycookiecheat/common.py
@@ -61,7 +61,11 @@ def generate_host_keys(hostname: str) -> Iterator[str]:
         yield "." + domain
 
 
-def _deprecation_warning(msg: str):
+def deprecation_warning(msg: str):
+    """Raise a deprecation warning with the provided message.
+
+    `stacklevel=3` tries to show the appropriate calling code to the user.
+    """
     warn(msg, DeprecationWarning, stacklevel=3)
 
 

--- a/src/pycookiecheat/common.py
+++ b/src/pycookiecheat/common.py
@@ -1,6 +1,6 @@
 """Common code for pycookiecheat."""
 from dataclasses import dataclass
-from enum import auto, Enum
+from enum import Enum
 from typing import Iterator
 from warnings import warn
 

--- a/src/pycookiecheat/firefox.py
+++ b/src/pycookiecheat/firefox.py
@@ -179,7 +179,7 @@ def firefox_cookies(
     browser: BrowserType = BrowserType.FIREFOX,
     curl_cookie_file: Optional[str] = None,
 ) -> Dict[str, str]:
-    """Retrieve cookies from Chrome/Chromium on OSX or Linux.
+    """Retrieve cookies from Firefox on MacOS or Linux.
 
     Args:
         url: Domain from which to retrieve cookies, starting with http(s)

--- a/src/pycookiecheat/firefox.py
+++ b/src/pycookiecheat/firefox.py
@@ -75,10 +75,7 @@ def _get_profiles_dir_for_os(
         raise ValueError(
             f"OS must be one of {list(FIREFOX_OS_PROFILE_DIRS.keys())}"
         )
-    try:
-        return Path(os_config[browser]).expanduser()
-    except KeyError:
-        raise ValueError(f"Browser must be one of {list(os_config.keys())}")
+    return Path(os_config[browser]).expanduser()
 
 
 def _find_firefox_default_profile(firefox_dir: Path) -> str:

--- a/src/pycookiecheat/firefox.py
+++ b/src/pycookiecheat/firefox.py
@@ -50,7 +50,7 @@ FIREFOX_OS_PROFILE_DIRS: Dict[str, Dict[str, str]] = {
     "linux": {
         BrowserType.FIREFOX: "~/.mozilla/firefox",
     },
-    "osx": {
+    "macos": {
         BrowserType.FIREFOX: "~/Library/Application Support/Firefox/Profiles",
     },
     "windows": {
@@ -197,7 +197,7 @@ def firefox_cookies(
     if sys.platform.startswith("linux"):
         os = "linux"
     elif sys.platform == "darwin":
-        os = "osx"
+        os = "macos"
     elif sys.platform == "win32":
         os = "windows"
     else:

--- a/src/pycookiecheat/firefox.py
+++ b/src/pycookiecheat/firefox.py
@@ -22,9 +22,9 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from pycookiecheat.common import (
-    _deprecation_warning,
     BrowserType,
     Cookie,
+    deprecation_warning,
     generate_host_keys,
 )
 
@@ -211,7 +211,7 @@ def firefox_cookies(
 
     # TODO: 20231229 remove str support after some deprecation period
     if not isinstance(browser, BrowserType):
-        _deprecation_warning(
+        deprecation_warning(
             "Please pass `browser` as a `BrowserType` instead of "
             f"`{browser.__class__.__qualname__}`."
         )

--- a/tests/test_chrome.py
+++ b/tests/test_chrome.py
@@ -52,7 +52,7 @@ def ci_setup() -> t.Generator:
             ignore_default_args=[
                 "--use-mock-keychain",
             ],
-            executable_path=ex_path,  # type: ignore
+            executable_path=ex_path,
         )
         page = browser.new_page()
         page.goto("https://n8henrie.com")

--- a/tests/test_chrome.py
+++ b/tests/test_chrome.py
@@ -165,3 +165,13 @@ def test_slack_config() -> None:
 
     for cfg in cfgs:
         assert "Slack" in str(cfg["cookie_file"])
+
+
+def test_macos_bad_browser_variant() -> None:
+    """Tests the error message resulting from unrecognized BrowserType."""
+
+    for invalid in [BrowserType.FIREFOX, "foo"]:
+        with pytest.raises(
+            ValueError, match=f"{invalid} is not a valid BrowserType"
+        ):
+            get_macos_config(invalid)

--- a/tests/test_chrome.py
+++ b/tests/test_chrome.py
@@ -173,4 +173,4 @@ def test_macos_bad_browser_variant() -> None:
         with pytest.raises(
             ValueError, match=f"{invalid} is not a valid BrowserType"
         ):
-            get_macos_config(invalid)
+            get_macos_config(invalid)  # type: ignore

--- a/tests/test_chrome.py
+++ b/tests/test_chrome.py
@@ -52,7 +52,7 @@ def ci_setup() -> t.Generator:
             ignore_default_args=[
                 "--use-mock-keychain",
             ],
-            executable_path=ex_path,
+            executable_path=ex_path,  # type: ignore
         )
         page = browser.new_page()
         page.goto("https://n8henrie.com")

--- a/tests/test_chrome.py
+++ b/tests/test_chrome.py
@@ -169,7 +169,6 @@ def test_slack_config() -> None:
 
 def test_macos_bad_browser_variant() -> None:
     """Tests the error message resulting from unrecognized BrowserType."""
-
     for invalid in [BrowserType.FIREFOX, "foo"]:
         with pytest.raises(
             ValueError, match=f"{invalid} is not a valid BrowserType"

--- a/tests/test_chrome.py
+++ b/tests/test_chrome.py
@@ -13,7 +13,7 @@ import pytest
 from playwright.sync_api import sync_playwright
 
 from pycookiecheat import BrowserType, chrome_cookies
-from pycookiecheat.chrome import get_linux_config, get_osx_config
+from pycookiecheat.chrome import get_linux_config, get_macos_config
 
 BROWSER = os.environ.get("TEST_BROWSER_NAME", "Chromium")
 
@@ -150,14 +150,14 @@ def test_slack_config() -> None:
     """
     cfgs = []
     if sys.platform == "darwin":
-        cfgs.append(get_osx_config(BrowserType("slack")))
+        cfgs.append(get_macos_config(BrowserType("slack")))
 
         parent = Path(
             "~/Library/Application Support/BraveSoftware/Brave-Browser/Default"
         )
         parent.mkdir(parents=True)
         (parent / "Cookies").touch()
-        cfgs.append(get_osx_config(BrowserType("slack")))
+        cfgs.append(get_macos_config(BrowserType("slack")))
 
         assert cfgs[0] != cfgs[1]
     else:

--- a/tests/test_chrome.py
+++ b/tests/test_chrome.py
@@ -150,18 +150,18 @@ def test_slack_config() -> None:
     """
     cfgs = []
     if sys.platform == "darwin":
-        cfgs.append(get_macos_config(BrowserType("slack")))
+        cfgs.append(get_macos_config(BrowserType.SLACK))
 
         parent = Path(
             "~/Library/Application Support/BraveSoftware/Brave-Browser/Default"
         )
         parent.mkdir(parents=True)
         (parent / "Cookies").touch()
-        cfgs.append(get_macos_config(BrowserType("slack")))
+        cfgs.append(get_macos_config(BrowserType.SLACK))
 
         assert cfgs[0] != cfgs[1]
     else:
-        cfgs.append(get_linux_config(BrowserType("SLACK")))
+        cfgs.append(get_linux_config(BrowserType.SLACK))
 
     for cfg in cfgs:
         assert "Slack" in str(cfg["cookie_file"])

--- a/tests/test_chrome.py
+++ b/tests/test_chrome.py
@@ -12,9 +12,8 @@ from uuid import uuid4
 import pytest
 from playwright.sync_api import sync_playwright
 
-from pycookiecheat import chrome_cookies
+from pycookiecheat import BrowserType, chrome_cookies
 from pycookiecheat.chrome import get_linux_config, get_osx_config
-from pycookiecheat.common import BrowserType
 
 BROWSER = os.environ.get("TEST_BROWSER_NAME", "Chromium")
 

--- a/tests/test_chrome.py
+++ b/tests/test_chrome.py
@@ -164,4 +164,4 @@ def test_slack_config() -> None:
         cfgs.append(get_linux_config(BrowserType("SLACK")))
 
     for cfg in cfgs:
-        assert "Slack" in cfg["cookie_file"]
+        assert "Slack" in str(cfg["cookie_file"])

--- a/tests/test_firefox.py
+++ b/tests/test_firefox.py
@@ -14,15 +14,13 @@ import pytest
 from playwright.sync_api import sync_playwright
 from pytest import FixtureRequest, TempPathFactory
 
-from pycookiecheat.common import BrowserType
+from pycookiecheat import BrowserType, firefox_cookies
 from pycookiecheat.firefox import (
     _find_firefox_default_profile,
     _get_profiles_dir_for_os,
     _load_firefox_cookie_db,
-    firefox_cookies,
     FirefoxProfileNotPopulatedError,
 )
-
 
 TEST_PROFILE_NAME = "test-profile"
 TEST_PROFILE_DIR = f"1234abcd.{TEST_PROFILE_NAME}"

--- a/tests/test_firefox.py
+++ b/tests/test_firefox.py
@@ -262,8 +262,10 @@ def test_get_profiles_dir_for_os_invalid() -> None:
     """Test invalid OS and browser names."""
     with pytest.raises(ValueError, match="OS must be one of"):
         _get_profiles_dir_for_os("invalid")
-    with pytest.raises(ValueError, match="Browser must be one of"):
-        _get_profiles_dir_for_os("linux", "invalid")  # type: ignore
+    with pytest.raises(
+        ValueError, match="'invalid' is not a valid BrowserType"
+    ):
+        _get_profiles_dir_for_os("linux", BrowserType("invalid"))
 
 
 # _find_firefox_default_profile()

--- a/tests/test_firefox.py
+++ b/tests/test_firefox.py
@@ -14,6 +14,7 @@ import pytest
 from playwright.sync_api import sync_playwright
 from pytest import FixtureRequest, TempPathFactory
 
+from pycookiecheat.common import BrowserType
 from pycookiecheat.firefox import (
     _find_firefox_default_profile,
     _get_profiles_dir_for_os,
@@ -255,7 +256,7 @@ def test_get_profiles_dir_for_os_valid(
     Test only implicit "Firefox" default, since it's the only type we currently
     support.
     """
-    profiles_dir = _get_profiles_dir_for_os(os_name, "Firefox")
+    profiles_dir = _get_profiles_dir_for_os(os_name, BrowserType.FIREFOX)
     assert profiles_dir == Path(expected_dir).expanduser()
 
 
@@ -264,7 +265,7 @@ def test_get_profiles_dir_for_os_invalid() -> None:
     with pytest.raises(ValueError, match="OS must be one of"):
         _get_profiles_dir_for_os("invalid")
     with pytest.raises(ValueError, match="Browser must be one of"):
-        _get_profiles_dir_for_os("linux", "invalid")
+        _get_profiles_dir_for_os("linux", "invalid")  # type: ignore
 
 
 # _find_firefox_default_profile()
@@ -335,6 +336,23 @@ def test_load_firefox_cookie_db_copy_error(
 def test_firefox_cookies(set_cookie: None) -> None:
     """Test getting Firefox cookies after visiting a site with cookies."""
     cookies = firefox_cookies("http://localhost", TEST_PROFILE_DIR)
+    assert len(cookies) > 0
+    assert cookies["foo"] == "bar"
+
+
+def test_warns_for_string_browser(set_cookie: None) -> None:
+    """Browser should be passed as `BrowserType` and warns for strings."""
+    with pytest.warns(
+        DeprecationWarning,
+        match=(
+            "Please pass `browser` as a `BrowserType` " "instead of `str`."
+        ),
+    ):
+        cookies = firefox_cookies(
+            "http://localhost",
+            TEST_PROFILE_DIR,
+            browser="firefox",  # type: ignore
+        )
     assert len(cookies) > 0
     assert cookies["foo"] == "bar"
 

--- a/tests/test_firefox.py
+++ b/tests/test_firefox.py
@@ -242,7 +242,7 @@ def set_cookie(profiles: Path, cookie_server: int) -> Iterator[None]:
     "os_name,expected_dir",
     [
         ("linux", "~/.mozilla/firefox"),
-        ("osx", "~/Library/Application Support/Firefox/Profiles"),
+        ("macos", "~/Library/Application Support/Firefox/Profiles"),
         ("windows", "~/AppData/Roaming/Mozilla/Firefox/Profiles"),
     ],
 )


### PR DESCRIPTION
Enums seem like a more correct way to provide discrete browser variants, and since they're easily available in Python for many versions now, I wanted to try passing an enum between functions internally instead of a string. This should provide much better type checking during development. As an additional advantage, any time it is necessary to accept a string from a user, this should be able to consolidate the parsing logic to a single location.

As StrEnum wasn't available until relatively late in the game, I used the "inherit from `str, Enum`" trick to allow easy comparisons:

```python
>>> browser = BrowserType.CHROME
>>> browser == "chrome"
True
>>> browser == "chromE"
False
```

... though I don't think I'm leveraging this anywhere so a straight `Enum` with `auto()` variants would likely have been fine.

Added a deprecation warning for users passing in strings; it should be minimal friction to adapt code from `browser="chrome"` to `browser=BrowserType("chrome")` or `browser=BrowserType.CHROME`.

This is partly in preparation for adding a CLI tool, which I hope to embark on soon (https://github.com/n8henrie/pycookiecheat/issues/60), and I intend to finally add some proper logging as well (https://github.com/n8henrie/pycookiecheat/issues/46)

Would appreciate any thoughts if you have time @grandchild!