### PR TITLE
Removed teh Profile directory from the Firefox root dir

### DIFF
--- a/src/pycookiecheat/firefox.py
+++ b/src/pycookiecheat/firefox.py
@@ -58,7 +58,7 @@ FIREFOX_OS_PROFILE_DIRS: dict[str, dict[str, str]] = {
         BrowserType.FIREFOX: "~/.mozilla/firefox",
     },
     "macos": {
-        BrowserType.FIREFOX: "~/Library/Application Support/Firefox/Profiles",
+        BrowserType.FIREFOX: "~/Library/Application Support/Firefox",
     },
     "windows": {
         BrowserType.FIREFOX: "~/AppData/Roaming/Mozilla/Firefox/Profiles",


### PR DESCRIPTION
Works on MacOS 14.6.1

NB: *Please* make an issue prior to embarking on any significant effort towards
a pull request. This will serve as a unified place for discussion and hopefully
make sure that the change seems reasonable to merge once its implementation is
complete.

## Description

MacOs stores Firefox profiles.ini under  ~/Library/Application Support/Firefox and not  ~/Library/Application Support/Firefox/Profiles

MacOs version: 14.6.1
Firefox Version: 129.0.1

## Status

**READY/IN DEVELOPMENT**

## Todos

- [ ] Detect if path exists; if not, add /Profiles
- [ ] Documentation
