### PR TITLE
Update keyring username for Slack.

### DIFF
--- a/src/pycookiecheat/chrome.py
+++ b/src/pycookiecheat/chrome.py
@@ -131,7 +131,7 @@ def get_macos_config(browser: BrowserType) -> dict:
 
     keyring_username = browser_name
     if browser is BrowserType.SLACK:
-        keyring_username = "Slack Key"
+        keyring_username = "Slack App Store Key"
 
     key_material = keyring.get_password(keyring_service_name, keyring_username)
     if key_material is None:


### PR DESCRIPTION
## Description

Just chasing the ever-changing internal details of Slack. Not sure when this change happened, it may have been quite some time ago, but it is present in version 4.39.95 of Slack for Mac.