### PR TITLE
Fix handling of cookies in Chromium cookie database versions >=24.

### DIFF
--- a/src/pycookiecheat/chrome.py
+++ b/src/pycookiecheat/chrome.py
@@ -66,7 +66,8 @@ def clean(decrypted: bytes) -> str:
 
 
 def chrome_decrypt(
-    encrypted_value: bytes, key: bytes, init_vector: bytes, cookie_database_version: int
+    encrypted_value: bytes, key: bytes, init_vector: bytes,
+    cookie_database_version: int
 ) -> str:
     """Decrypt Chrome/Chromium's encrypted cookies.
 
@@ -89,7 +90,8 @@ def chrome_decrypt(
     decrypted = decryptor.update(encrypted_value) + decryptor.finalize()
 
     if cookie_database_version >= 24:
-        # Cookies in database version 24 and later include a SHA256 hash of the domain to the start of the encrypted value.
+        # Cookies in database version 24 and later include a SHA256
+        # hash of the domain to the start of the encrypted value.
         decrypted = decrypted[32:]
 
     return clean(decrypted)

--- a/src/pycookiecheat/chrome.py
+++ b/src/pycookiecheat/chrome.py
@@ -321,7 +321,15 @@ def chrome_cookies(
     conn.text_factory = bytes
 
     sql = "select value from meta where key = 'version';"
-    cookie_database_version = int(conn.execute(sql).fetchone()[0])
+    cookie_database_version = 0
+    try:
+        row = conn.execute(sql).fetchone()
+        if row:
+            cookie_database_version = int(row[0])
+        else:
+            logger.info("cookie database version not found in meta table")
+    except sqlite3.OperationalError as e:
+        logger.info("cookie database is missing meta table")
 
     # Check whether the column name is `secure` or `is_secure`
     secure_column_name = "is_secure"

--- a/src/pycookiecheat/chrome.py
+++ b/src/pycookiecheat/chrome.py
@@ -66,8 +66,10 @@ def clean(decrypted: bytes) -> str:
 
 
 def chrome_decrypt(
-    encrypted_value: bytes, key: bytes, init_vector: bytes,
-    cookie_database_version: int
+    encrypted_value: bytes,
+    key: bytes,
+    init_vector: bytes,
+    cookie_database_version: int,
 ) -> str:
     """Decrypt Chrome/Chromium's encrypted cookies.
 

--- a/src/pycookiecheat/chrome.py
+++ b/src/pycookiecheat/chrome.py
@@ -92,6 +92,9 @@ def chrome_decrypt(
     if cookie_database_version >= 24:
         # Cookies in database version 24 and later include a SHA256
         # hash of the domain to the start of the encrypted value.
+        # https://github.com/chromium/chromium/blob/
+        # 280265158d778772c48206ffaea788c1030b9aaa/net/extras/
+        # sqlite/sqlite_persistent_cookie_store.cc#L223-L224
         decrypted = decrypted[32:]
 
     return clean(decrypted)

--- a/src/pycookiecheat/chrome.py
+++ b/src/pycookiecheat/chrome.py
@@ -313,6 +313,7 @@ def chrome_cookies(
         raise e
 
     conn.row_factory = sqlite3.Row
+    conn.text_factory = bytes
 
     sql = "select value from meta where key = 'version';"
     cookie_database_version = int(conn.execute(sql).fetchone()[0])
@@ -354,6 +355,9 @@ def chrome_cookies(
                     cookie_database_version=cookie_database_version,
                 )
             del row["encrypted_value"]
+            for key, value in row.items():
+                if isinstance(value, bytes):
+                    row[key] = value.decode("utf8")
             cookies.append(Cookie(**row))
 
     conn.rollback()

--- a/src/pycookiecheat/chrome.py
+++ b/src/pycookiecheat/chrome.py
@@ -328,7 +328,7 @@ def chrome_cookies(
             cookie_database_version = int(row[0])
         else:
             logger.info("cookie database version not found in meta table")
-    except sqlite3.OperationalError as e:
+    except sqlite3.OperationalError:
         logger.info("cookie database is missing meta table")
 
     # Check whether the column name is `secure` or `is_secure`


### PR DESCRIPTION
NB: *Please* make an issue prior to embarking on any significant effort towards
a pull request. This will serve as a unified place for discussion and hopefully
make sure that the change seems reasonable to merge once its implementation is
complete.

## Description
This attempts to fix the problem described in #72, which I believe I've identified as being caused by the Chromium cookie database format changing to include a SHA256 hash of the domain for the cookie as part of the encrypted value.

To handle this case, I've extracted the database version of the cookie database. If it is greater than 24, I remove the first 32 bytes of the encrypted value before it is passed to clean.

I've also added a fix for not being able to read the value from the database at all, by treating all database strings as byte strings and then decoding them to UTF-8 only after decryption has happened.

## Status

**READY**

## Related Issues
Fixes #72.

## Todos

- [ ] Tests
- [ ] Documentation

## Steps to Test or Reproduce

E.g.:

```bash
git checkout -b <feature_branch> master
git pull https://github.com/<user>/pycookiecheat.git <feature_branch>
pytest tests/
```

## Other notes


