### PR TITLE
Add command line option to set cookie file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ with a standalone console script:
 
 ```console
 $ pycookiecheat --help
-usage: pycookiecheat [-h] -u URL [-b BROWSER] [-o OUTPUT_FILE]
+usage: pycookiecheat [-h] -u URL [-b BROWSER] [-o OUTPUT_FILE] [--verbose]
+                     [-c COOKIE_FILE]
 
 Copy cookies from Chrome or Firefox and output as json
 
@@ -63,6 +64,9 @@ options:
   -b BROWSER, --browser BROWSER
   -o OUTPUT_FILE, --output-file OUTPUT_FILE
                         Output to this file in netscape cookie file format
+  --verbose, -v         Increase logging verbosity (may repeat), default is `logging.ERROR`
+  -c COOKIE_FILE, --cookie-file COOKIE_FILE
+                        Cookie file
 ```
 
 ### As a Python Library

--- a/src/pycookiecheat/__main__.py
+++ b/src/pycookiecheat/__main__.py
@@ -34,6 +34,11 @@ def main() -> None:
             "`logging.ERROR`"
         ),
     )
+    parser.add_argument(
+        "-c",
+        "--cookie-file",
+        help="Cookie file",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=max(logging.ERROR - 10 * args.verbose, 0))
@@ -48,12 +53,14 @@ def main() -> None:
             url=args.url,
             browser=browser,
             curl_cookie_file=args.output_file,
+            cookie_file=args.cookie_file,
         )
     else:
         cookies = chrome_cookies(
             url=args.url,
             browser=browser,
             curl_cookie_file=args.output_file,
+            cookie_file=args.cookie_file,
         )
 
     if not args.output_file:


### PR DESCRIPTION
## Description

Add ability to specify a cookie file on command line.

## Status

READY

Note: https://github.com/chrisgavin/pycookiecheat/tree/handle-v24-cookies needs to be applied for testing to work


## Related Issues

- [67](https://github.com/n8henrie/pycookiecheat/issues/67)

## Todos

- [x] Tests
- [x] Documentation

## Steps to Test or Reproduce

```
$ pycookiecheat -u https://google.com | sort | head -1
    "AEC": "AVYB7coIGnG..."

$ pycookiecheat -u https://google.com -c ~/Library/Application\ Support/Google/Chrome/Default/Cookies | sort | head -1
    "AEC": "AVYB7coIGnG..."

$ pycookiecheat -u https://google.com -c ~/Library/Application\ Support/Google/Chrome/Profile\ 3/Cookies | sort | head -1
    "AEC": "AVYB7cqeSEq..."

$ pycookiecheat -u https://google.com --cookie-file ~/Library/Application\ Support/Google/Chrome/Profile\ 3/Cookies | sort | head  -1
    "AEC": "AVYB7cqeSEq..."
```

## Other notes


