### PR TITLE
Add command line option --version

### DIFF
--- a/src/pycookiecheat/__main__.py
+++ b/src/pycookiecheat/__main__.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import logging
 
+from importlib.metadata import version
 from .chrome import chrome_cookies
 from .common import BrowserType
 from .firefox import firefox_cookies
@@ -33,6 +34,12 @@ def main() -> None:
             "Increase logging verbosity (may repeat), default is "
             "`logging.ERROR`"
         ),
+    )
+    parser.add_argument(
+        "-V",
+        "--version",
+        action='version',
+        version=version(parser.prog),
     )
     args = parser.parse_args()
 

--- a/src/pycookiecheat/__main__.py
+++ b/src/pycookiecheat/__main__.py
@@ -26,8 +26,8 @@ def main() -> None:
         help="Output to this file in netscape cookie file format",
     )
     parser.add_argument(
-        "--verbose",
         "-v",
+        "--verbose",
         action="count",
         default=0,
         help=(


### PR DESCRIPTION
## Description

Add `--version` option to command line.

## Status

READY

## Related Issues

- [66](https://github.com/n8henrie/pycookiecheat/issues/66)

## Todos

- [x] Tests
- [x] Documentation

## Steps to Test or Reproduce

I bumped version for testing purposes.

```
$ pycookiecheat -V
0.8.0
$ pycookiecheat --version
0.8.0
```

## Other notes

I moved `-v` option first so help is consistent; single char options first, long options second.
You may want to update README to reflect that, but I'll leave that to you.

