### PR TITLE
Add support for managed Firefox

### DIFF
--- a/src/pycookiecheat/firefox.py
+++ b/src/pycookiecheat/firefox.py
@@ -107,7 +107,18 @@ def _find_firefox_default_profile(firefox_dir: Path) -> str:
     profiles_ini.read(firefox_dir / "profiles.ini")
     installs = [s for s in profiles_ini.sections() if s.startswith("Install")]
     if installs:  # Firefox >= 67
-        # Heuristic: Take the most recently created profile which should be the active one.
+        """
+        Default to last Firefox install if multiple
+
+        When _not_ explicitly requesting a specific Firefox profile directory
+        the default profile is chosen. However on top of profiles Firefox may
+        have multiple "installs" (listed in the `installs.ini` file) each with
+        their own default profile.
+        
+        Before, the default profile was the one from the first install.
+        However, it makes more sense to pick the last one instead, assuming
+        that that's the most recently created one, and thus the active one.
+        """
         return profiles_ini[installs[-1]]["Default"]
     else:  # Firefox < 67
         profiles = [

--- a/src/pycookiecheat/firefox.py
+++ b/src/pycookiecheat/firefox.py
@@ -107,18 +107,7 @@ def _find_firefox_default_profile(firefox_dir: Path) -> str:
     profiles_ini.read(firefox_dir / "profiles.ini")
     installs = [s for s in profiles_ini.sections() if s.startswith("Install")]
     if installs:  # Firefox >= 67
-        """
-        Default to last Firefox install if multiple
-
-        When _not_ explicitly requesting a specific Firefox profile directory
-        the default profile is chosen. However on top of profiles Firefox may
-        have multiple "installs" (listed in the `installs.ini` file) each with
-        their own default profile.
-        
-        Before, the default profile was the one from the first install.
-        However, it makes more sense to pick the last one instead, assuming
-        that that's the most recently created one, and thus the active one.
-        """
+        # Heuristic: Take the most recently created profile which should be the active one.
         return profiles_ini[installs[-1]]["Default"]
     else:  # Firefox < 67
         profiles = [

--- a/src/pycookiecheat/firefox.py
+++ b/src/pycookiecheat/firefox.py
@@ -107,8 +107,8 @@ def _find_firefox_default_profile(firefox_dir: Path) -> str:
     profiles_ini.read(firefox_dir / "profiles.ini")
     installs = [s for s in profiles_ini.sections() if s.startswith("Install")]
     if installs:  # Firefox >= 67
-        # Heuristic: Take the first install, that's probably the system install
-        return profiles_ini[installs[0]]["Default"]
+        # Heuristic: Take the most recently created profile which should be the active one.
+        return profiles_ini[installs[-1]]["Default"]
     else:  # Firefox < 67
         profiles = [
             s for s in profiles_ini.sections() if s.startswith("Profile")


### PR DESCRIPTION
NB: *Please* make an issue prior to embarking on any significant effort towards
a pull request. This will serve as a unified place for discussion and hopefully
make sure that the change seems reasonable to merge once its implementation is
complete.

## Description

Without the change, the wrong Firefox profile was being loaded and no cookies were coming through. My organization manages Firefox so we have multiple "default-release" profiles in the profiles.ini file. It seems with managed Firefox browsers, users will be stuck on the most recently created profile so I switched the profile selection behavior to grab the last profile instead of the first. In theory this shouldn't break anything since the most recently created profile should be the active one anyway.

## Status

**READY**

